### PR TITLE
Have the initContainer use user provided UID and GID

### DIFF
--- a/charts/trilium/Chart.yaml
+++ b/charts/trilium/Chart.yaml
@@ -8,7 +8,7 @@ description: |-
   Build your personal knowledge base with Trilium Notes. A hierarchical note taking application with focus on building large personal knowledge bases.
 annotations:
   category: Notes
-version: 1.2.0
+version: 1.2.1
 appVersion: 0.90.4
 kubeVersion: ">= 1.19"
 dependencies:

--- a/charts/trilium/templates/release.yaml
+++ b/charts/trilium/templates/release.yaml
@@ -6,7 +6,7 @@ controllers:
         image:
           repository: busybox
           tag: latest
-          args: ["sh", "-c", "chown -R {{ .Values.controllers.main.containers.trilium.securityContext.runas | default 1000 }}:{{ .Values.controllers.main.containers.trilium.securityContext.runas | default 1000 }} /home/node/trilium-data"]
+          args: ["sh", "-c", "chown -R {{ .Values.permissions.runAsUser }}:{{ .Values.permissions.runAsGroup }} /home/node/trilium-data"]
         securityContext:
           runAsUser: 0
           runAsGroup: 0
@@ -43,10 +43,10 @@ controllers:
           liveness: *probes
         # Defines what user and group the container should run as
         securityContext:
-          runAsUser: 1000
-          runAsGroup: 1000
-          fsGroup: 1000
-          fsGroupChangePolicy: OnRootMismatch
+          runAsUser: {{ .Values.permissions.runAsUser }}
+          runAsGroup: {{ .Values.permissions.runAsGroup }}
+          fsGroup: {{ .Values.permissions.fsGroup }}
+          fsGroupChangePolicy: {{ .Values.permissions.fsGroupChangePolicy }}
 
 
 persistence:

--- a/charts/trilium/templates/release.yaml
+++ b/charts/trilium/templates/release.yaml
@@ -6,7 +6,7 @@ controllers:
         image:
           repository: busybox
           tag: latest
-        args: ["sh", "-c", "chown -R 1000:1000 /home/node/trilium-data"]
+          args: ["sh", "-c", "chown -R {{ .Values.controllers.main.containers.trilium.securityContext.runas | default 1000 }}:{{ .Values.controllers.main.containers.trilium.securityContext.runas | default 1000 }} /home/node/trilium-data"]
         securityContext:
           runAsUser: 0
           runAsGroup: 0
@@ -41,7 +41,12 @@ controllers:
               httpGet: *probesPath
 
           liveness: *probes
-
+        # Defines what user and group the container should run as
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          fsGroup: 1000
+          fsGroupChangePolicy: OnRootMismatch
 
 
 persistence:

--- a/charts/trilium/templates/release.yaml
+++ b/charts/trilium/templates/release.yaml
@@ -6,7 +6,7 @@ controllers:
         image:
           repository: busybox
           tag: latest
-          args: ["sh", "-c", "chown -R {{ .Values.permissions.runAsUser }}:{{ .Values.permissions.runAsGroup }} /home/node/trilium-data"]
+        args: ["sh", "-c", "chown -R {{ .Values.permissions.runAsUser }}:{{ .Values.permissions.runAsGroup }} /home/node/trilium-data"]
         securityContext:
           runAsUser: 0
           runAsGroup: 0

--- a/charts/trilium/templates/release.yaml
+++ b/charts/trilium/templates/release.yaml
@@ -16,6 +16,9 @@ controllers:
           repository: triliumnext/notes
           tag: v0.90.4
           pullPolicy: IfNotPresent
+        env:
+          USER_UID: {{ .Values.permissions.runAsUser }}
+          USER_GID: {{ .Values.permissions.runAsGroup }}
 
         probes:
           startup:
@@ -42,9 +45,9 @@ controllers:
 
           liveness: *probes
         # Defines what user and group the container should run as
+        # Trilium needs to run as root initially to allow the start-docker.sh to 
+        # change the user/group permissions that we set
         securityContext:
-          runAsUser: {{ .Values.permissions.runAsUser }}
-          runAsGroup: {{ .Values.permissions.runAsGroup }}
           fsGroup: {{ .Values.permissions.fsGroup }}
           fsGroupChangePolicy: {{ .Values.permissions.fsGroupChangePolicy }}
 

--- a/charts/trilium/values.yaml
+++ b/charts/trilium/values.yaml
@@ -20,6 +20,13 @@ persistence:
     type: persistentVolumeClaim
     existingClaim:
 
+# Define permissions for the containers (the UID and GID of the user running the container)
+permissions:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+
 # This is used to modify the config.ini of the Trilium instance
 configini:
   general:

--- a/charts/trilium/values.yaml
+++ b/charts/trilium/values.yaml
@@ -11,8 +11,8 @@ controllers:
           repository: triliumnext/notes
           tag: v0.90.4
           pullPolicy: IfNotPresent
-        env:
-          key: "value"
+        #env:
+        #  key: "value"
 
 persistence:
   data:


### PR DESCRIPTION
Have the initContainer use the user provided UID and GID, which it then runs `chown` for, against the Trilium data on their behalf.