### PR TITLE
chore: Update Trilium chart dependencies

### DIFF
--- a/charts/trilium/Chart.yaml
+++ b/charts/trilium/Chart.yaml
@@ -13,8 +13,8 @@ appVersion: 0.92.4
 kubeVersion: ">= 1.19"
 dependencies:
   - name: common
-    repository: https://bjw-s.github.io/helm-charts
-    version: 3.3.2
+    repository: https://bjw-s-labs.github.io/helm-charts
+    version: 4.5.0
 keywords:
   - electron
   - wiki


### PR DESCRIPTION
Updates the common dependency in the Trilium Helm chart from version 3.3.2 to 4.5.0 and changes the repository URL from bjw-s.github.io/helm-charts to bjw-s-labs.github.io/helm-charts.