### PR TITLE
fix: Update Trilium repository URL and image to v0.100.0

### DIFF
--- a/charts/trilium/Chart.yaml
+++ b/charts/trilium/Chart.yaml
@@ -9,7 +9,7 @@ description: |-
 annotations:
   category: Notes
 version: 1.3.0
-appVersion: 0.92.4
+appVersion: 0.100.0
 kubeVersion: ">= 1.19"
 dependencies:
   - name: common
@@ -37,10 +37,10 @@ keywords:
   - local-first
 maintainers:
   - name: triliumnext
-    url: https://github.com/TriliumNext/Notes
+    url: https://github.com/TriliumNext/Trilium
   - name: perfectra1n
     email: jon@jonfuller.io
     url: https://perf3ct.tech
 sources:
   - https://github.com/TriliumNext/helm-charts
-  - hhttps://github.com/TriliumNext/Notes
+  - https://github.com/TriliumNext/Trilium

--- a/charts/trilium/templates/release.yaml
+++ b/charts/trilium/templates/release.yaml
@@ -12,11 +12,6 @@ controllers:
           runAsGroup: 0
     containers:
       trilium:
-        image:
-          repository: triliumnext/notes
-          tag: v0.90.8
-          pullPolicy: IfNotPresent
-
         probes:
           startup:
             enabled: true
@@ -42,8 +37,6 @@ controllers:
 
           liveness: *probes
 
-
-
 persistence:
   data:
     enabled: true
@@ -65,8 +58,6 @@ persistence:
         trilium:
           - path: /home/node/trilium-data/config.ini
             subPath: config.ini
-    
-
 
 service:
   main:

--- a/charts/trilium/values.yaml
+++ b/charts/trilium/values.yaml
@@ -8,8 +8,8 @@ controllers:
     containers:
       trilium:
         image:
-          repository: triliumnext/notes
-          tag: v0.92.4
+          repository: triliumnext/trilium
+          tag: v0.100.0
           pullPolicy: IfNotPresent
         env:
           key: "value"


### PR DESCRIPTION
Updated Trilium repository references and upgraded to the latest version.

- Updated the maintainer URL from `https://github.com/TriliumNext/Notes` to `https://github.com/TriliumNext/Trilium`
- Changed the image repository from `triliumnext/notes` to `triliumnext/trilium`
- Upgraded the image tag from `v0.92.4` to `v0.100.0`
- Removed duplicate image configuration from the release.yaml template