### PR TITLE
ci: use a PAT for release-please and post manifest diff comments

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -123,9 +123,19 @@ jobs:
             echo "# failed to build dependencies for the chart on main" > base/manifest.yaml
           fi
 
-      - name: Comment manifest diff
+      - name: Render manifest diff
+        id: diff
         if: steps.changes.outputs.chart == 'true'
         uses: int128/diff-action@d568d28eca4411ad141d5cd5f84c7b739a0956ce # v2.31.0
         with:
           base: base
           head: head
+
+      - name: Comment manifest diff
+        if: steps.changes.outputs.chart == 'true'
+        uses: int128/comment-action@9448863881c42b4c69f213d9a67c8b37e7c0f105 # v1.68.0
+        with:
+          update-if-exists: replace
+          post: |
+            ## Changes in the rendered manifests
+            ${{ steps.diff.outputs.comment-body || 'No changes detected.' }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -26,10 +26,15 @@ jobs:
       tag_name: ${{ steps.release.outputs['charts/trilium--tag_name'] }}
       version: ${{ steps.release.outputs['charts/trilium--version'] }}
     steps:
+      # A PAT (RELEASE_PLEASE_TOKEN) is used instead of GITHUB_TOKEN because
+      # the org policy does not allow Actions to create pull requests, and a
+      # PAT-created release PR also gets normal PR validation runs. Falls back
+      # to GITHUB_TOKEN when the secret is not set.
       - name: Release Please
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Why

Two CI fixes from the #14 branch were pushed a few minutes after that PR was merged, so they never landed on main:

1. The post-merge Release Please run failed with "GitHub Actions is not permitted to create or approve pull requests" because the org policy blocks the built-in GITHUB_TOKEN from creating PRs. The workflow now uses the RELEASE_PLEASE_TOKEN secret (already configured in the repo) with a fallback to GITHUB_TOKEN.
2. The manifest diff comment never appeared on PRs: diff-action v2 only formats the diff into an output, so int128/comment-action is needed to actually post it.

## After merging

Trigger the Release Please workflow once (it has workflow_dispatch) or wait for the next push to main. It will open the "release trilium 2.0.0" PR using the PAT, with the changelog built from the feat! commit in #14.
